### PR TITLE
Wait for FIFO availability before write

### DIFF
--- a/firmware/bolt/main.c
+++ b/firmware/bolt/main.c
@@ -189,10 +189,12 @@ int parse_scpi_command(const char *command) {
       } else {
         char buf[64];
         for (int i = 0; i < ADC_SAMPLES; i++) {
-          snprintf(buf, 63, "%u,", data[i]);
+          int len = snprintf(buf, 63, "%u,", data[i]);
           tud_cdc_n_write(COMMAND_ITF, buf, strlen(buf));
           tud_cdc_n_write_flush(COMMAND_ITF);
-          tud_task();
+          while ((uint32_t)len > tud_cdc_n_write_available(COMMAND_ITF)) {
+            tud_task(); // Allow TinyUSB to handle background tasks
+          }
         }
         tud_cdc_n_write_char(COMMAND_ITF, '\n');
         tud_cdc_n_write_flush(COMMAND_ITF);


### PR DESCRIPTION
Change to wait for room in the FIFO buffer before proceeding with the next write. This fixes the issue of getting "Got [any number smaller than 50000] entries, skipping" when plotting (`plot_last_trace()`). The underlying issue was `get_last_trace()` not receiving the full ADC sampled buffer (50k entries). The reason the full buffer wasn't received, is probably that the host PC is not fast enough to read out the USB buffer, resulting in the Bolt dropping packets when the USB FIFO gets full.
With this fix, I can successfully plot the graph. I've tested on Debian 13, Python3.14.