### PR TITLE
Firmware build instructions

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -26,3 +26,27 @@ You can get the Bolt to send programmable output patterns on its output GPIO, ba
 Documentation for this is in progress.
 
 ⚠️ **NOTE FOR ECSC23 PARTICIPANTS**: the scope of your Bolt is not necessary for your challenges, and it will not help you either. For the competition you can ignore this feature.
+
+## Build from sources
+
+If you would like to make changes to the Curious Bolt firmware, you can follow these build instructions. [Clone](https://docs.github.com/en/repositories/creating-and-managing-repositories/cloning-a-repository) the [Bolt repository](https://github.com/tjclement/bolt).
+
+### Build with Docker (Windows/Linux/MacOS)
+
+To build on any operating system, we've provided a Dockerfile. Use as follows:
+1. Install Docker: [Windows](https://docs.docker.com/desktop/setup/install/windows-install/), [Linux](https://docs.docker.com/desktop/setup/install/linux/), or [MacOS](https://docs.docker.com/desktop/setup/install/mac-install/)
+    - On Linux, you can also install the lighter-but-no-GUI [Docker Engine](https://docs.docker.com/engine/) 
+2. In a terminal, go to the repo folder `bolt/firmware/bolt`
+3. Build the bolt-builder `sudo docker build -t bolt-builder .`
+    - This will build the docker image from `Dockerfile` in the current folder. This docker file will contain all neccessary packages for building the Bolt firmware.
+4. Use the bolt-builder `sudo docker run --rm -it -v "$(pwd)":/project bolt-builder /build.sh`
+    - This will build the UF2 image that we can install on the Curious Bolt
+    - The built image can be found in `bolt/firmware/bolt/build/glitcher.uf2`
+5. Go to the directory where you put `scope.py` see [Setting up your Bolt](#setting-up-your-bolt).
+    - Alternatively, `scope.py` is also in this repo `bolt/lib/scope.py`
+6. Put the Bolt in bootloader mode `python3 -c "from scope import Scope; s=Scope(); s.update()"`
+    - If successful, the bootloader LEDs will turn off, the USB device disconnects, and reconnects as a storage device.
+7. Put the `glitcher.uf2` we built earlier on the newly connected storage device. After some time, the device should disconnect again and boot into the updated firmware. 
+
+### Unbricking the Bolt
+If you modified the code in such a way that it can't be put into bootloader mode anymore using `scope.py`, then find the two test points next to the USB connector (TP1 and TP2 on the [schematic](https://github.com/tjclement/bolt/blob/main/hardware/bolt/schematics.pdf)). Unplug the Bolt, short the two testpoints, and connect the Bolt to your computer. It should now connect in bootloader mode, allowing you to flash your firmware again.

--- a/firmware/bolt/Dockerfile
+++ b/firmware/bolt/Dockerfile
@@ -1,0 +1,26 @@
+# Use an official Ubuntu base image
+FROM debian:trixie-slim
+
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    tzdata \
+    build-essential \
+    cmake \
+    gcc-arm-none-eabi \
+    libnewlib-arm-none-eabi \
+    libstdc++-arm-none-eabi-newlib \
+    git \
+    ca-certificates \
+    python3 
+ 
+RUN rm -rf /var/lib/apt/lists/*
+
+# Add the build script inside the container
+COPY build.sh /build.sh
+RUN chmod +x /build.sh
+
+# Set working directory inside the container
+WORKDIR /project
+
+# Default command to run when starting container (can be overridden)
+CMD ["bash"]

--- a/firmware/bolt/build.sh
+++ b/firmware/bolt/build.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+mkdir -p build
+cmake -S . -B build
+make -C build

--- a/firmware/bolt/pico_sdk_import.cmake
+++ b/firmware/bolt/pico_sdk_import.cmake
@@ -3,6 +3,28 @@
 # This can be dropped into an external project to help locate this SDK
 # It should be include()ed prior to project()
 
+# Copyright 2020 (c) 2020 Raspberry Pi (Trading) Ltd.
+#
+# Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+# following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+# disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following
+# disclaimer in the documentation and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products
+# derived from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+# INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+# WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+# THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
 if (DEFINED ENV{PICO_SDK_PATH} AND (NOT PICO_SDK_PATH))
     set(PICO_SDK_PATH $ENV{PICO_SDK_PATH})
     message("Using PICO_SDK_PATH from environment ('${PICO_SDK_PATH}')")
@@ -18,9 +40,20 @@ if (DEFINED ENV{PICO_SDK_FETCH_FROM_GIT_PATH} AND (NOT PICO_SDK_FETCH_FROM_GIT_P
     message("Using PICO_SDK_FETCH_FROM_GIT_PATH from environment ('${PICO_SDK_FETCH_FROM_GIT_PATH}')")
 endif ()
 
+if (DEFINED ENV{PICO_SDK_FETCH_FROM_GIT_TAG} AND (NOT PICO_SDK_FETCH_FROM_GIT_TAG))
+    set(PICO_SDK_FETCH_FROM_GIT_TAG $ENV{PICO_SDK_FETCH_FROM_GIT_TAG})
+    message("Using PICO_SDK_FETCH_FROM_GIT_TAG from environment ('${PICO_SDK_FETCH_FROM_GIT_TAG}')")
+endif ()
+
+if (PICO_SDK_FETCH_FROM_GIT AND NOT PICO_SDK_FETCH_FROM_GIT_TAG)
+  set(PICO_SDK_FETCH_FROM_GIT_TAG "master")
+  message("Using master as default value for PICO_SDK_FETCH_FROM_GIT_TAG")
+endif()
+
 set(PICO_SDK_PATH "${PICO_SDK_PATH}" CACHE PATH "Path to the Raspberry Pi Pico SDK")
 set(PICO_SDK_FETCH_FROM_GIT "${PICO_SDK_FETCH_FROM_GIT}" CACHE BOOL "Set to ON to fetch copy of SDK from git if not otherwise locatable")
 set(PICO_SDK_FETCH_FROM_GIT_PATH "${PICO_SDK_FETCH_FROM_GIT_PATH}" CACHE FILEPATH "location to download SDK")
+set(PICO_SDK_FETCH_FROM_GIT_TAG "${PICO_SDK_FETCH_FROM_GIT_TAG}" CACHE FILEPATH "release tag for SDK")
 
 if (NOT PICO_SDK_PATH)
     if (PICO_SDK_FETCH_FROM_GIT)
@@ -29,25 +62,40 @@ if (NOT PICO_SDK_PATH)
         if (PICO_SDK_FETCH_FROM_GIT_PATH)
             get_filename_component(FETCHCONTENT_BASE_DIR "${PICO_SDK_FETCH_FROM_GIT_PATH}" REALPATH BASE_DIR "${CMAKE_SOURCE_DIR}")
         endif ()
-        # GIT_SUBMODULES_RECURSE was added in 3.17
-        if (${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.17.0")
-            FetchContent_Declare(
-                    pico_sdk
-                    GIT_REPOSITORY https://github.com/raspberrypi/pico-sdk
-                    GIT_TAG master
-                    GIT_SUBMODULES_RECURSE FALSE
-            )
-        else ()
-            FetchContent_Declare(
-                    pico_sdk
-                    GIT_REPOSITORY https://github.com/raspberrypi/pico-sdk
-                    GIT_TAG master
-            )
-        endif ()
+        FetchContent_Declare(
+                pico_sdk
+                GIT_REPOSITORY https://github.com/raspberrypi/pico-sdk
+                GIT_TAG ${PICO_SDK_FETCH_FROM_GIT_TAG}
+        )
 
         if (NOT pico_sdk)
             message("Downloading Raspberry Pi Pico SDK")
-            FetchContent_Populate(pico_sdk)
+            # GIT_SUBMODULES_RECURSE was added in 3.17
+            if (${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.17.0")
+                FetchContent_Populate(
+                        pico_sdk
+                        QUIET
+                        GIT_REPOSITORY https://github.com/raspberrypi/pico-sdk
+                        GIT_TAG ${PICO_SDK_FETCH_FROM_GIT_TAG}
+                        GIT_SUBMODULES_RECURSE FALSE
+
+                        SOURCE_DIR ${FETCHCONTENT_BASE_DIR}/pico_sdk-src
+                        BINARY_DIR ${FETCHCONTENT_BASE_DIR}/pico_sdk-build
+                        SUBBUILD_DIR ${FETCHCONTENT_BASE_DIR}/pico_sdk-subbuild
+                )
+            else ()
+                FetchContent_Populate(
+                        pico_sdk
+                        QUIET
+                        GIT_REPOSITORY https://github.com/raspberrypi/pico-sdk
+                        GIT_TAG ${PICO_SDK_FETCH_FROM_GIT_TAG}
+
+                        SOURCE_DIR ${FETCHCONTENT_BASE_DIR}/pico_sdk-src
+                        BINARY_DIR ${FETCHCONTENT_BASE_DIR}/pico_sdk-build
+                        SUBBUILD_DIR ${FETCHCONTENT_BASE_DIR}/pico_sdk-subbuild
+                )
+            endif ()
+
             set(PICO_SDK_PATH ${pico_sdk_SOURCE_DIR})
         endif ()
         set(FETCHCONTENT_BASE_DIR ${FETCHCONTENT_BASE_DIR_SAVE})


### PR DESCRIPTION
Made a Dockerfile so the firmware can easily be compiled on any OS, including documentation on how to build the firmware this way. 

While compiling the firmware, I ran into CMake warning about some future deprecation in `pico_sdk_import.cmake`. Updated this to the newest from [raspberrypi/pico-sdk](https://github.com/raspberrypi/pico-sdk/blob/master/external/pico_sdk_import.cmake), solving this issue. Forgive me for smashing both into the same PR ^